### PR TITLE
Use JSON.parse for Shopify.onError

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -397,7 +397,15 @@ Shopify.onItemAdded = function(line_item) {
 };
 
 Shopify.onError = function(XMLHttpRequest, textStatus) {
-    var data = eval('(' + XMLHttpRequest.responseText + ')');
+    var data;
+
+    try {
+        data = JSON.parse(XMLHttpRequest.responseText);
+    } catch (e) {
+        console.error('Could not parse error response', e);
+        alert('An unexpected error occurred.');
+        return;
+    }
 
     if (!!data.message) {
         alert(data.message + '(' + data.status  + '): ' + data.description);


### PR DESCRIPTION
## Summary
- Replace eval-based parsing with JSON.parse in Shopify.onError
- Add try-catch around JSON parsing with a fallback alert

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895106e967c8324a00829729e41d888