### PR TITLE
Add alt attribute to Meta Pixel noscript image

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -85,7 +85,7 @@ s.parentNode.insertBefore(t,s)}(window, document,'script',
 fbq('init', '781012302931779');
 fbq('track', 'PageView');
 </script>
-<noscript><img height="1" width="1" style="display:none"
+<noscript><img height="1" width="1" style="display:none" alt=""
 src="https://www.facebook.com/tr?id=781012302931779&ev=PageView&noscript=1"
 /></noscript>
 <!-- End Meta Pixel Code -->


### PR DESCRIPTION
## Summary
- add empty alt attribute to Meta Pixel `<noscript>` image to satisfy accessibility requirements

## Testing
- `npx --yes @shopify/theme-check@latest` *(fails: Not Found - GET https://registry.npmjs.org/@shopify%2ftheme-check - Not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68951069798883249b0e4bf0676bf770