### PR TITLE
Ensure product images render when loading effect enabled

### DIFF
--- a/snippets/product-card-loading.liquid
+++ b/snippets/product-card-loading.liquid
@@ -45,38 +45,37 @@
                         style="padding-bottom: 100%;"
                     {% endif %}
                 >
+                    {%- if product_card_product.featured_media -%}
+                        <img srcset="
+                            {%- if product_card_product.featured_media.width >= 165 -%}
+                                {{ product_card_product.featured_media | img_url: '165x' }} 165w,
+                            {%- endif -%}
+                            {%- if product_card_product.featured_media.width >= 360 -%}
+                                {{ product_card_product.featured_media | img_url: '360x' }} 360w,
+                            {%- endif -%}
+                            {%- if product_card_product.featured_media.width >= 533 -%}
+                                {{ product_card_product.featured_media | img_url: '533x' }} 533w,
+                            {%- endif -%}
+                            {%- if product_card_product.featured_media.width >= 720 -%}
+                                {{ product_card_product.featured_media | img_url: '720x' }} 720w,
+                            {%- endif -%}
+                            {%- if product_card_product.featured_media.width >= 940 -%}
+                                {{ product_card_product.featured_media | img_url: '940x' }} 940w,
+                            {%- endif -%}
+                            {%- if product_card_product.featured_media.width >= 1066 -%}
+                                {{ product_card_product.featured_media | img_url: '1066x' }} 1066w
+                            {%- endif -%}"
+                            src="{{ product_card_product.featured_media | img_url: '533x' }}"
+                            sizes="(min-width: 1100px) 535px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
+                            alt="{{ product_card_product.featured_media.alt | escape }}"
+                            class="lazyload"
+                        >
+                    {%- else -%}
+                        {% capture current %}{% cycle 1, 2, 3, 4, 5, 6 %}{% endcapture %}
+                        {{ 'product-' | append: current | placeholder_svg_tag: 'placeholder-svg' }}
+                    {%- endif -%}
                     {%- if settings.show_image_loading -%}
                         <div class="media-loading" data-title="{{ settings.image_loading_text }}">{{ settings.image_loading_text }}</div>
-                    {%- else -%}
-                        {%- if product_card_product.featured_media -%}
-                            <img srcset="
-                                {%- if product_card_product.featured_media.width >= 165 -%}
-                                    {{ product_card_product.featured_media | img_url: '165x' }} 165w,
-                                {%- endif -%}
-                                {%- if product_card_product.featured_media.width >= 360 -%}
-                                    {{ product_card_product.featured_media | img_url: '360x' }} 360w,
-                                {%- endif -%}
-                                {%- if product_card_product.featured_media.width >= 533 -%}
-                                    {{ product_card_product.featured_media | img_url: '533x' }} 533w,
-                                {%- endif -%}
-                                {%- if product_card_product.featured_media.width >= 720 -%}
-                                    {{ product_card_product.featured_media | img_url: '720x' }} 720w,
-                                {%- endif -%}
-                                {%- if product_card_product.featured_media.width >= 940 -%}
-                                    {{ product_card_product.featured_media | img_url: '940x' }} 940w,
-                                {%- endif -%}
-                                {%- if product_card_product.featured_media.width >= 1066 -%}
-                                    {{ product_card_product.featured_media | img_url: '1066x' }} 1066w
-                                {%- endif -%}"
-                                src="{{ product_card_product.featured_media | img_url: '533x' }}"
-                                sizes="(min-width: 1100px) 535px, (min-width: 750px) calc((100vw - 130px) / 2), calc((100vw - 50px) / 2)"
-                                alt="{{ product_card_product.featured_media.alt | escape }}"
-                                class="lazyload"
-                            >
-                        {%- else -%}
-                            {% capture current %}{% cycle 1, 2, 3, 4, 5, 6 %}{% endcapture %}
-                            {{ 'product-' | append: current | placeholder_svg_tag: 'placeholder-svg' }}
-                        {%- endif -%}
                     {%- endif -%}
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Always include real product images in `product-card-loading` so lazyload placeholders get replaced

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689510a28488832482a2cca81565d718