### PR TITLE
fix: prevent lazyload styles from hiding images

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -128,14 +128,14 @@ div[class^='card style-']{
 }
 
 .media--loading-effect > img.lazyload,
-.media--loading-effect > img.lazyloading{
-    opacity: 0!important;
+.media--loading-effect > img.lazyloading {
+    opacity: 1;
 }
 
 .media--loading-effect > img.lazyload ~ .media-loading,
 .media--loading-effect > img.lazyloading ~ .media-loading,
-.card-media--loading .media-loading{
-    display: block;
+.card-media--loading .media-loading {
+    display: none;
 }
 
 .card-information{


### PR DESCRIPTION
## Summary
- ensure media images remain visible even when lazy-loading by removing opacity and skeleton overlay rules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895248163608324a01fe1f55b5f1bd2